### PR TITLE
ignore non-city query params

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -1965,6 +1965,17 @@ function getCityId() {
     if (CITY_DATA[locationParam]) {
       return locationParam;
     }
+    // it might be a bare parameter mixed in with non-cth params, e.g.
+    // ?dane-county-municipalities&fbclid=IwAR3_xoxxxxx
+    // so as a last option let's look at all the params and see if
+    // we find a city
+    bareParam = false;
+    urlParams.forEach(function (searchVal, searchKey) {
+      if (CITY_DATA[searchKey]) {
+        bareParam = searchKey;
+      }
+    });
+    return bareParam;
   }
 
   return false;


### PR DESCRIPTION
CTH has gone back and forth in how it handled the URL for linking right to a game for a specific neighborhood. Originally it was query strings (e.g. click-that-hood.com/?africa), and in #108 and #233 it got changed to resource names (e.g. click-that-hood.com/africa), and then recently Falco changed it back to query strings, because that makes hosting the game as a static webpage easier. 

(In a clever approach for backwards compatibility to still support URLs with the "nicer" resource names now that the game is hosted via static html on github pages, the game index.html is also copied to the 404.html page, so when someone visits click-that-hood.com/africa, it's technically a 404 not found error, but as the game is also served as the 404 page, the game looks to see what you were trying to visit and plays that game)

I didn't go digging to see the full history here, but the game has also supported not just blank params, like ?africa, but also a key-value version, e.g. click-that-hood.com/?location=africa and ?city=africa - I don't know if it always did that or if it got added sometime after the initial version of the game) 

But at any rate, since 2014 basically everything has just worked - cth.com/africa, cth.com/?africa, and cth.com/?location=africa

Several years ago Facebook added trackers to outbound links, e.g. every link shared on facebook became cth.com/africa?fbclid=xxxyyyzzz. It's annoying and I think technically isn't following the specs (I don't think the format of the query string is actually specified, and while it's usually true that it's formatted as k1=v1&k2=v2 and sites normally just ignore unknown keys, I don't actually think that's in the specs). At any rate, Facebook is doing it and so the rest of us who just live in Zuck's metaverse have to deal with it. 

The change FB made worked fine for the resource-name version - https://click-that-hood.com/africa?fbclid=123234 is fine because the javascript code looks first for `location.pathname` which doesn't have the query params. However, it breaks the query-param version of the game, because for the case where we're not using the key/value option (e.g. we're not looking for city=africa or location=africa) - the game assumes the entire search query is the city name and doesn't try to parse it first. And since October of 2021 in https://github.com/codeforgermany/click_that_hood/commit/2cf5d7918b45b7218bec7914503e1c234468e4e4 the default for CTH is to use the query string version as the default URLs the game creates. 

This PR fixes mangled URLs that have extra query parameters in the URL by adding a new fallback that checks the query string **after** the query string has been parsed and looks for a key that matches a cityname, so cth.com/?africa&fbclid=xxxx should work now. (It even works if you for some reasons someone adds a value, e.g. cth.com/?new-york-city-boroughs=bigapple though I don't know why that would ever happen ) 

In the unlikely event that someone uses two citynames in the URL, the last city is the usually that's used, e.g. /?new-york-city-boroughs&africa will usually play the Africa version of the game - but that depends on the forEach order and I don't think Javascript guarantees the order of forEach.

 